### PR TITLE
build(npm): dist 를 node-dev의 ignore path에서 제거

### DIFF
--- a/1_typescript/.node-dev.json
+++ b/1_typescript/.node-dev.json
@@ -1,7 +1,6 @@
 {
   "notify": false,
   "ignore": [
-    "node_modules",
-    "dist"
+    "node_modules"
   ]
 }

--- a/2_nexus/.node-dev.json
+++ b/2_nexus/.node-dev.json
@@ -1,7 +1,6 @@
 {
   "notify": false,
   "ignore": [
-    "node_modules",
-    "dist"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
소스코드(index.ts)가 dist에 의존하지 않아서 dist는 처음부터 watch 되지 않는 걸로 생각합니다. 
명시적으로 제외하지 않아도 원래 ignore 되므로 dist를 제거하였습니다.